### PR TITLE
Update for prisma 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.8.6",
-        "prisma": "^5.7.1",
+        "prisma": "^6.0.1",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -40,53 +40,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.21.1.tgz",
-      "integrity": "sha512-uY8SAhcnORhvgtOrNdvWS98Aq/nkQ9QDUxrWAgW8XrCZaI3j2X7zb7Xe6GQSh6xSesKffFbFlkw0c2luHQviZA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.0.1.tgz",
+      "integrity": "sha512-jQylgSOf7ibTVxqBacnAlVGvek6fQxJIYCQOeX2KexsfypNzXjJQSS2o5s+Mjj2Np93iSOQUaw6TvPj8syhG4w==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.21.1.tgz",
-      "integrity": "sha512-hGVTldUkIkTwoV8//hmnAAiAchi4oMEKD3aW5H2RrnI50tTdwza7VQbTTAyN3OIHWlK5DVg6xV7X8N/9dtOydA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.0.1.tgz",
+      "integrity": "sha512-4hxzI+YQIR2uuDyVsDooFZGu5AtixbvM2psp+iayDZ4hRrAHo/YwgA17N23UWq7G6gRu18NvuNMb48qjP3DPQw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1",
-        "@prisma/engines-version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-        "@prisma/fetch-engine": "5.21.1",
-        "@prisma/get-platform": "5.21.1"
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/fetch-engine": "6.0.1",
+        "@prisma/get-platform": "6.0.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36.tgz",
-      "integrity": "sha512-qvnEflL0//lh44S/T9NcvTMxfyowNeUxTunPcDfKPjyJNrCNf2F1zQLcUv5UHAruECpX+zz21CzsC7V2xAeM7Q==",
+      "version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e.tgz",
+      "integrity": "sha512-JmIds0Q2/vsOmnuTJYxY4LE+sajqjYKhLtdOT6y4imojqv5d/aeVEfbBGC74t8Be1uSp0OP8lxIj2OqoKbLsfQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.21.1.tgz",
-      "integrity": "sha512-70S31vgpCGcp9J+mh/wHtLCkVezLUqe/fGWk3J3JWZIN7prdYSlr1C0niaWUyNK2VflLXYi8kMjAmSxUVq6WGQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.0.1.tgz",
+      "integrity": "sha512-T36bWFVGeGYYSyYOj9d+O9G3sBC+pAyMC+jc45iSL63/Haq1GrYjQPgPMxrEj9m739taXrupoysRedQ+VyvM/Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1",
-        "@prisma/engines-version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-        "@prisma/get-platform": "5.21.1"
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/get-platform": "6.0.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.21.1.tgz",
-      "integrity": "sha512-sRxjL3Igst3ct+e8ya/x//cDXmpLbZQ5vfps2N4tWl4VGKQAmym77C/IG/psSMsQKszc8uFC/q1dgmKFLUgXZQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.0.1.tgz",
+      "integrity": "sha512-zspC9vlxAqx4E6epMPMLLBMED2VD8axDe8sPnquZ8GOsn6tiacWK0oxrGK4UAHYzYUVuMVUApJbdXB2dFpLhvg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1"
+        "@prisma/debug": "6.0.1"
       }
     },
     "node_modules/@types/node": {
@@ -115,20 +115,20 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.21.1.tgz",
-      "integrity": "sha512-PB+Iqzld/uQBPaaw2UVIk84kb0ITsLajzsxzsadxxl54eaU5Gyl2/L02ysivHxK89t7YrfQJm+Ggk37uvM70oQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.0.1.tgz",
+      "integrity": "sha512-CaMNFHkf+DDq8zq3X/JJsQ4Koy7dyWwwtOKibkT/Am9j/tDxcfbg7+lB1Dzhx18G/+RQCMgjPYB61bhRqteNBQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.21.1"
+        "@prisma/engines": "6.0.1"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^22.8.6",
-    "prisma": "^5.7.1",
+    "prisma": "^6.0.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@prisma/client": "^4.7.0 || 5"
+    "@prisma/client": "^4.7.0 || 5 || 6"
   },
   "files": [
     "/lib"


### PR DESCRIPTION
https://github.com/prisma/prisma/releases/tag/6.0.0

*N.B.* 

> The new minimum supported Node.js versions for Prisma ORM v6 are:
>
> for Node.js 18 the minimum supported version is 18.18.0
> for Node.js 20 the minimum supported version is 20.9.0
> for Node.js 22 the minimum supported version is 22.11.0

Consider bumping the engines in package.json to only support these versions?