### PR TITLE
Correctly apply `this` when calling prisma original functions so that…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 - 2025-01-23
+### Fixed
+- This package now passes the correct `this` context when calling Prisma functions
+  - This fixes a bug which caused `Prisma.getExtensionContext(this)` to be `undefined` when writing custom Prisma client extensions
+
 ## 1.3.0 - 2024-12-09
 ### Added
 - Added support for Prisma 6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chax-at/transactional-prisma-testing",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Provides an easy way to execute database tests in a transaction that will be rolled back after each test for fast testing",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
… client extensions can access it.

Fixes #17